### PR TITLE
Update SnackViewInListView.UWP.csproj

### DIFF
--- a/SnackViewInListView/SnackViewInListView/SnackViewInListView.UWP/SnackViewInListView.UWP.csproj
+++ b/SnackViewInListView/SnackViewInListView/SnackViewInListView.UWP/SnackViewInListView.UWP.csproj
@@ -150,7 +150,7 @@
       <Version>16.3.0.29</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.561731" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SnackViewInListView\SnackViewInListView.csproj">


### PR DESCRIPTION
Updated Microsoft.NETCore.UniversalWindow package version is upgraded to resolve below vulnerablity issue.

https://github.com/SyncfusionExamples/How-to-show-the-snack-bar-at-the-bottom-of-listview-uwp/security/dependabot/1